### PR TITLE
Leaderboard now uses memberID

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "eslint.enable": false,
+    "standard.enable": false
+}

--- a/commands/guess.js
+++ b/commands/guess.js
@@ -89,7 +89,6 @@ module.exports = {
     
                             let guildMember = {
                                 memberID: collected.first().author.id, 
-                                username: collected.first().author.username,
                                 level: 1
                             }
 
@@ -104,12 +103,6 @@ module.exports = {
                             
                             let guildMember = guildLeaderboard.data.find(x => x.memberID === collected.first().author.id)
 
-                            console.log(guildMember.username == collected.first().author.username)
-
-                            if(guildMember.username != collected.first().author.username){
-                                console.log("test");
-                                guildMember.username = collected.first().author.username;
-                            }
                             guildMember.level = guildMember.level + 1;
 
                             fs.writeFile(`${leaderboardPath}`, JSON.stringify (guildLeaderboard, null, 2), err => {

--- a/commands/leaderboard.js
+++ b/commands/leaderboard.js
@@ -32,7 +32,16 @@ module.exports = {
             .setFooter({text: `${language.credits}`})
  
         for(let i = 0; i < config.leaderboardLength && i < leaderboard.length; i++) {
-            leaderboardEmbed.addField(`${i + 1}. ${leaderboard[i].username}`, `${language.lbEmbedLevel} ${leaderboard[i].level}`, config.leaderboardInline)
+
+            let guildMember = await interaction.guild.members.fetch(leaderboard[i].memberID);
+
+            leaderboardEmbed.addField(
+                `${i + 1}. ${guildMember.displayName}`, 
+                `${language.lbEmbedLevel} ${leaderboard[i].level}`, 
+                config.leaderboardInline
+            )
+
+
         }
 
         await interaction.reply({embeds: [leaderboardEmbed]});

--- a/leaderboards/927523748775612496.json
+++ b/leaderboards/927523748775612496.json
@@ -1,9 +1,0 @@
-{
-  "data": [
-    {
-      "memberID": "392776445375545355",
-      "username": "Nils",
-      "level": 1
-    }
-  ]
-}

--- a/leaderboards/927523748775612496.json
+++ b/leaderboards/927523748775612496.json
@@ -1,0 +1,9 @@
+{
+  "data": [
+    {
+      "memberID": "392776445375545355",
+      "username": "Nils",
+      "level": 1
+    }
+  ]
+}


### PR DESCRIPTION
The leaderboard command now uses the memberID and not the first cached username to display the display name.